### PR TITLE
fgdispacther pass culling

### DIFF
--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
@@ -42,6 +42,8 @@ ResourceAccessGraph::ResourceAccessGraph(const allocator_type& alloc) noexcept
   passIndex(alloc),
   resourceNames(alloc),
   resourceIndex(alloc),
+  leafPasses(alloc),
+  culledPasses(alloc),
   accessRecord(alloc) {}
 
 // ContinuousContainer

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
@@ -42,7 +42,6 @@ ResourceAccessGraph::ResourceAccessGraph(const allocator_type& alloc) noexcept
   passIndex(alloc),
   resourceNames(alloc),
   resourceIndex(alloc),
-  externalPasses(alloc),
   accessRecord(alloc) {}
 
 // ContinuousContainer

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -41,6 +41,7 @@
 #include "cocos/renderer/pipeline/custom/LayoutGraphTypes.h"
 #include "cocos/renderer/pipeline/custom/Map.h"
 #include "cocos/renderer/pipeline/custom/RenderGraphTypes.h"
+#include "cocos/renderer/pipeline/custom/Set.h"
 #include "gfx-base/GFXDef-common.h"
 
 namespace cc {
@@ -48,6 +49,11 @@ namespace cc {
 namespace render {
 
 struct NullTag {};
+
+struct LeafStatus {
+    bool isExternal{false};
+    bool needCulling{false};
+};
 
 struct BufferRange {
     uint32_t offset{0};
@@ -227,9 +233,10 @@ struct ResourceAccessGraph {
     // Members
     ccstd::pmr::vector<ccstd::pmr::string> resourceNames;
     PmrUnorderedStringMap<ccstd::pmr::string, uint32_t> resourceIndex;
-    RenderGraph::vertex_descriptor                      presentPassID{0xFFFFFFFF};
-    std::map<RenderGraph::vertex_descriptor, std::pair<bool,bool>>    leafPasses;
-    PmrFlatMap<uint32_t, ResourceTransition>            accessRecord;
+    RenderGraph::vertex_descriptor presentPassID{0xFFFFFFFF};
+    PmrFlatMap<RenderGraph::vertex_descriptor, LeafStatus> leafPasses;
+    PmrFlatSet<RenderGraph::vertex_descriptor> culledPasses;
+    PmrFlatMap<uint32_t, ResourceTransition> accessRecord;
 };
 
 struct EmptyGraph {

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -227,9 +227,9 @@ struct ResourceAccessGraph {
     // Members
     ccstd::pmr::vector<ccstd::pmr::string> resourceNames;
     PmrUnorderedStringMap<ccstd::pmr::string, uint32_t> resourceIndex;
-    RenderGraph::vertex_descriptor presentPassID{0xFFFFFFFF};
-    ccstd::pmr::vector<RenderGraph::vertex_descriptor> externalPasses;
-    PmrFlatMap<uint32_t, ResourceTransition> accessRecord;
+    RenderGraph::vertex_descriptor                      presentPassID{0xFFFFFFFF};
+    std::map<RenderGraph::vertex_descriptor, std::pair<bool,bool>>    leafPasses;
+    PmrFlatMap<uint32_t, ResourceTransition>            accessRecord;
 };
 
 struct EmptyGraph {

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -56,7 +56,7 @@ namespace cc {
 
 namespace render {
 
-static constexpr bool enableBranchCulling = true;
+static constexpr bool ENABLE_BRANCH_CULLING = true;
 
 void passReorder(FrameGraphDispatcher &fgDispatcher);
 void memoryAliasing(FrameGraphDispatcher &fgDispatcher);
@@ -277,7 +277,7 @@ void buildAccessGraph(const RenderGraph &renderGraph, const Graphs &graphs) {
             }
         } else {
             // write into transient resources, culled
-            if constexpr (enableBranchCulling) {
+            if constexpr (ENABLE_BRANCH_CULLING) {
                 branchCulling(pass.first, resourceAccessGraph);
             }
         }

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -56,6 +56,8 @@ namespace cc {
 
 namespace render {
 
+static constexpr bool enableBranchCulling = true;
+
 void passReorder(FrameGraphDispatcher &fgDispatcher);
 void memoryAliasing(FrameGraphDispatcher &fgDispatcher);
 void buildBarriers(FrameGraphDispatcher &fgDispatcher);
@@ -153,7 +155,7 @@ gfx::MemoryAccessBit toGfxAccess(AccessType type) {
 };
 
 // AccessStatus.vertID : in resourceNode it's resource ID; in barrierNode it's pass ID.
-AccessVertex dependencyCheck(RAG &rag, AccessVertex curVertID, const ViewStatus &status);
+AccessVertex dependencyCheck(RAG &rag, AccessVertex curVertID, const ResourceGraph &rg, const ViewStatus &status);
 gfx::ShaderStageFlagBit getVisibilityByDescName(const LGD &lgd, uint32_t passID, const PmrString &slotName);
 
 void addAccessStatus(RAG &rag, const ResourceGraph &rg, ResourceAccessNode &node, const ViewStatus &status);
@@ -182,7 +184,7 @@ void buildAccessGraph(const RenderGraph &renderGraph, const Graphs &graphs) {
     // what we need:
     //  - pass dependency
     //  - pass attachment access
-    //AccessTable accessRecord;
+    // AccessTable accessRecord;
 
     size_t numPasses = 1;
     numPasses += renderGraph.rasterPasses.size();
@@ -196,6 +198,10 @@ void buildAccessGraph(const RenderGraph &renderGraph, const Graphs &graphs) {
     resourceAccessGraph.reserve(static_cast<ResourceAccessGraph::vertices_size_type>(numPasses));
     resourceAccessGraph.resourceNames.reserve(128);
     resourceAccessGraph.resourceIndex.reserve(128);
+
+    for (size_t i = 1; i <= renderGraph.vertices.size(); ++i) {
+        resourceAccessGraph.leafPasses.emplace(i, std::make_pair<bool, bool>(false, false));
+    }
 
     auto startID = add_vertex(resourceAccessGraph, INVALID_ID);
     CC_EXPECTS(startID == EXPECT_START_ID);
@@ -225,10 +231,44 @@ void buildAccessGraph(const RenderGraph &renderGraph, const Graphs &graphs) {
             });
     }
 
+    auto &rag = resourceAccessGraph;
+    auto branchCulling = [](ResourceAccessGraph::vertex_descriptor vertex, ResourceAccessGraph &rag) -> void {
+        CC_EXPECTS(out_degree(vertex, rag) == 0);
+        using FuncType = void (*)(ResourceAccessGraph::vertex_descriptor, ResourceAccessGraph &);
+        static FuncType leafCulling = [](ResourceAccessGraph::vertex_descriptor vertex, ResourceAccessGraph &rag) {
+            auto inEdges = in_edges(vertex, rag);
+            for (auto iter = inEdges.first; iter < inEdges.second;) {
+                auto inEdge = *iter;
+                auto srcVert = source(inEdge, rag);
+                remove_edge(inEdge, rag);
+                if (out_degree(srcVert, rag) == 0) {
+                    leafCulling(srcVert, rag);
+                }
+                inEdges = in_edges(vertex, rag);
+                iter = inEdges.first;
+            }
+        };
+        leafCulling(vertex, rag);
+    };
+
+    for (auto pass : resourceAccessGraph.leafPasses) {
+        printf("%d\n", pass.first);
+    }
+
     // make leaf node closed walk for pass reorder
-    for (auto pass : resourceAccessGraph.externalPasses) {
-        if (out_degree(pass, resourceAccessGraph) == 0) {
-            add_edge(pass, resourceAccessGraph.presentPassID, resourceAccessGraph);
+    for (auto pass : resourceAccessGraph.leafPasses) {
+        bool isExternal = pass.second.first;
+        bool needCulling = pass.second.second;
+
+        if (isExternal && !needCulling) {
+            if (pass.first != resourceAccessGraph.presentPassID) {
+                add_edge(pass.first, resourceAccessGraph.presentPassID, resourceAccessGraph);
+            }
+        } else {
+            // write into transient resources, culled
+            if constexpr (enableBranchCulling) {
+                branchCulling(pass.first, resourceAccessGraph);
+            }
         }
     }
 }
@@ -1327,7 +1367,7 @@ void addAccessStatus(RAG &rag, const ResourceGraph &rg, ResourceAccessNode &node
     });
 }
 
-AccessVertex dependencyCheck(RAG &rag, AccessVertex curVertID, const ViewStatus &viewStatus) {
+AccessVertex dependencyCheck(RAG &rag, AccessVertex curVertID, const ResourceGraph &rg, const ViewStatus &viewStatus) {
     const auto &[name, passType, visibility, access] = viewStatus;
     auto &accessRecord = rag.accessRecord;
 
@@ -1341,26 +1381,42 @@ AccessVertex dependencyCheck(RAG &rag, AccessVertex curVertID, const ViewStatus 
             ResourceTransition{
                 {},
                 {curVertID, visibility, access, passType, Range{}}});
+        if ((get(get(ResourceGraph::Traits, rg), resourceID).hasSideEffects() || passType == PassType::PRESENT)) {
+            rag.leafPasses[curVertID] = std::make_pair<bool, bool>(true, access == gfx::MemoryAccessBit::READ_ONLY && passType != PassType::PRESENT);
+        }
     } else {
         ResourceTransition &trans = iter->second;
         if (access == gfx::MemoryAccessBit::READ_ONLY && trans.currStatus.access == gfx::MemoryAccessBit::READ_ONLY &&
-            trans.currStatus.passType == passType && trans.currStatus.visibility == visibility) {
+            (trans.currStatus.passType == passType || passType == PassType::PRESENT) && trans.currStatus.visibility == visibility) {
             // current READ, no WRITE before in this frame, it's expected to be external.
             bool dirtyExternalRes = trans.lastStatus.vertID == INVALID_ID;
             if (!dirtyExternalRes) {
                 tryAddEdge(trans.lastStatus.vertID, curVertID, rag);
+                if (rag.leafPasses.find(trans.lastStatus.vertID) != rag.leafPasses.end()) {
+                    rag.leafPasses.erase(trans.lastStatus.vertID);
+                }
+            }
+            if ((get(get(ResourceGraph::Traits, rg), resourceID).hasSideEffects() || passType == PassType::PRESENT)) {
+                rag.leafPasses[curVertID] = std::make_pair<bool, bool>(true, access == gfx::MemoryAccessBit::READ_ONLY && passType != PassType::PRESENT);
             }
             trans.currStatus = {curVertID, visibility, access, passType, Range{}};
             lastVertID = trans.lastStatus.vertID;
-            rag.externalPasses.emplace_back(curVertID);
         } else {
             bool needTransition = (trans.currStatus.access != access) || (trans.currStatus.passType != passType) || (trans.currStatus.visibility != visibility);
             // avoid subpass self depends
             if (needTransition && trans.currStatus.vertID != curVertID) {
+                lastVertID = trans.currStatus.vertID;
                 trans.lastStatus = trans.currStatus;
                 trans.currStatus = {curVertID, visibility, access, passType, Range{}};
-                tryAddEdge(trans.lastStatus.vertID, curVertID, rag);
-                lastVertID = trans.lastStatus.vertID;
+                if (rag.leafPasses.find(trans.lastStatus.vertID) != rag.leafPasses.end()) {
+                    rag.leafPasses.erase(trans.lastStatus.vertID);
+                }
+                if (rag.leafPasses.find(curVertID) != rag.leafPasses.end()) {
+                    // only write into externalRes counts
+                    if ((get(get(ResourceGraph::Traits, rg), resourceID).hasSideEffects() || passType == PassType::PRESENT)) {
+                        rag.leafPasses[curVertID] = std::make_pair<bool, bool>(true, access == gfx::MemoryAccessBit::READ_ONLY && passType != PassType::PRESENT);
+                    }
+                }
             }
         }
     }
@@ -1398,7 +1454,7 @@ bool checkRasterViews(const Graphs &graphs, uint32_t vertID, uint32_t passID, Pa
         auto access = toGfxAccess(rasterView.accessType);
         ViewStatus viewStatus{rasterView.slotName, passType, visibility, access};
         addAccessStatus(resourceAccessGraph, resourceGraph, node, viewStatus);
-        auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, viewStatus);
+        auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, resourceGraph, viewStatus);
         if (lastVertId != INVALID_ID && lastVertId != vertID) {
             tryAddEdge(lastVertId, vertID, resourceAccessGraph);
             tryAddEdge(lastVertId, vertID, relationGraph);
@@ -1423,7 +1479,7 @@ bool checkComputeViews(const Graphs &graphs, uint32_t vertID, uint32_t passID, P
             auto access = toGfxAccess(computeView.accessType);
             ViewStatus viewStatus{computeView.name, passType, visibility, access};
             addAccessStatus(resourceAccessGraph, resourceGraph, node, viewStatus);
-            auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, viewStatus);
+            auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, resourceGraph, viewStatus);
             if (lastVertId != INVALID_ID) {
                 tryAddEdge(lastVertId, vertID, resourceAccessGraph);
                 tryAddEdge(lastVertId, vertID, relationGraph);
@@ -1529,13 +1585,13 @@ void processCopyPass(const Graphs &graphs, uint32_t passID, const CopyPass &pass
         ViewStatus dstViewStatus{pair.target, PassType::COPY, defaultVisibility, gfx::MemoryAccessBit::WRITE_ONLY};
         addCopyAccessStatus(resourceAccessGraph, resourceGraph, node, dstViewStatus, targetRange);
 
-        uint32_t lastVertSrc = dependencyCheck(resourceAccessGraph, vertID, srcViewStatus);
+        uint32_t lastVertSrc = dependencyCheck(resourceAccessGraph, vertID, resourceGraph, srcViewStatus);
         if (lastVertSrc != INVALID_ID) {
             tryAddEdge(lastVertSrc, vertID, resourceAccessGraph);
             tryAddEdge(lastVertSrc, rlgVertID, relationGraph);
             dependent = true;
         }
-        uint32_t lastVertDst = dependencyCheck(resourceAccessGraph, vertID, dstViewStatus);
+        uint32_t lastVertDst = dependencyCheck(resourceAccessGraph, vertID, resourceGraph, dstViewStatus);
         if (lastVertDst != INVALID_ID) {
             tryAddEdge(lastVertDst, vertID, resourceAccessGraph);
             tryAddEdge(lastVertDst, rlgVertID, relationGraph);
@@ -1578,7 +1634,7 @@ void processPresentPass(const Graphs &graphs, uint32_t passID, const PresentPass
         gfx::ShaderStageFlagBit visibility = getVisibilityByDescName(layoutGraphData, passID, pair.first);
         ViewStatus viewStatus{pair.first, PassType::PRESENT, visibility, gfx::MemoryAccessBit::READ_ONLY};
 
-        auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, viewStatus);
+        auto lastVertId = dependencyCheck(resourceAccessGraph, vertID, resourceGraph, viewStatus);
         addAccessStatus(resourceAccessGraph, resourceGraph, node, viewStatus);
         if (lastVertId != INVALID_ID) {
             tryAddEdge(lastVertId, vertID, resourceAccessGraph);

--- a/native/cocos/renderer/pipeline/custom/test/test.h
+++ b/native/cocos/renderer/pipeline/custom/test/test.h
@@ -665,6 +665,14 @@ static void runTestGraph(const RenderGraph &renderGraph, const ResourceGraph &re
          {ResourceDimension::TEXTURE2D, 4, 960, 640, 1, 0, Format::RGBA8, SampleCount::ONE, TextureFlagBit::NONE, ResourceFlags::SAMPLED | ResourceFlags::COLOR_ATTACHMENT}, \
          {ResourceResidency::EXTERNAL},                                                                                                                                      \
          {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
+        {"21",                                                                                                                                                               \
+         {ResourceDimension::TEXTURE2D, 4, 960, 640, 1, 0, Format::RGBA8, SampleCount::ONE, TextureFlagBit::NONE, ResourceFlags::SAMPLED | ResourceFlags::COLOR_ATTACHMENT}, \
+         {ResourceResidency::EXTERNAL},                                                                                                                                      \
+         {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
+        {"22",                                                                                                                                                               \
+         {ResourceDimension::TEXTURE2D, 4, 960, 640, 1, 0, Format::RGBA8, SampleCount::ONE, TextureFlagBit::NONE, ResourceFlags::SAMPLED | ResourceFlags::COLOR_ATTACHMENT}, \
+         {ResourceResidency::EXTERNAL},                                                                                                                                      \
+         {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
     };
 
 #define TEST_CASE_1                                                      \
@@ -1039,18 +1047,26 @@ static void runTestGraph(const RenderGraph &renderGraph, const ResourceGraph &re
             PassType::RASTER,                                  \
             {                                                  \
                 {{"2"}, {"7"}},                                \
+                {{"7"}, {"20"}},                               \
             },                                                 \
         },                                                     \
         {                                                      \
             PassType::RASTER,                                  \
             {                                                  \
-                {{"7"}, {"8"}},                                \
+                {{"2", "21"}, {"8"}},                          \
+                {{"8"}, {"9"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"2"}, {"10"}},                               \
             },                                                 \
         },                                                     \
         {                                                      \
             PassType::PRESENT,                                 \
             {                                                  \
-                {{"7"}, {}},                                   \
+                {{"10"}, {}},                                  \
             },                                                 \
         },                                                     \
     };                                                         \
@@ -1086,13 +1102,20 @@ static void runTestGraph(const RenderGraph &renderGraph, const ResourceGraph &re
         {                                                      \
             {"2", 2, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
             {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"20", 20, cc::gfx::ShaderStageFlagBit::FRAGMENT}, \
         },                                                     \
         {                                                      \
-            {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"2", 2, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
             {"8", 8, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"9", 9, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"21", 21, cc::gfx::ShaderStageFlagBit::FRAGMENT}, \
         },                                                     \
         {                                                      \
-            {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"2", 2, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"10", 10, cc::gfx::ShaderStageFlagBit::FRAGMENT}, \
+        },                                                     \
+        {                                                      \
+            {"10", 10, cc::gfx::ShaderStageFlagBit::FRAGMENT}, \
         },                                                     \
     };
 } // namespace render

--- a/native/cocos/renderer/pipeline/custom/test/test.h
+++ b/native/cocos/renderer/pipeline/custom/test/test.h
@@ -659,11 +659,11 @@ static void runTestGraph(const RenderGraph &renderGraph, const ResourceGraph &re
          {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
         {"19",                                                                                                                                                               \
          {ResourceDimension::TEXTURE2D, 4, 960, 640, 1, 0, Format::RGBA8, SampleCount::ONE, TextureFlagBit::NONE, ResourceFlags::SAMPLED | ResourceFlags::COLOR_ATTACHMENT}, \
-         {ResourceResidency::MANAGED},                                                                                                                                       \
+         {ResourceResidency::EXTERNAL},                                                                                                                                      \
          {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
         {"20",                                                                                                                                                               \
          {ResourceDimension::TEXTURE2D, 4, 960, 640, 1, 0, Format::RGBA8, SampleCount::ONE, TextureFlagBit::NONE, ResourceFlags::SAMPLED | ResourceFlags::COLOR_ATTACHMENT}, \
-         {ResourceResidency::MANAGED},                                                                                                                                       \
+         {ResourceResidency::EXTERNAL},                                                                                                                                      \
          {AccessFlagBit::FRAGMENT_SHADER_READ_TEXTURE | AccessFlagBit::COLOR_ATTACHMENT_WRITE}},                                                                             \
     };
 
@@ -989,581 +989,111 @@ static void runTestGraph(const RenderGraph &renderGraph, const ResourceGraph &re
         },                                                     \
     };
 
-/*
-void testCase1() {
-    boost::container::pmr::memory_resource *resource = boost::container::pmr::get_default_resource();
-    RenderGraph renderGraph(resource);
-    ResourceGraph rescGraph(resource);
-    LayoutGraphData layoutGraph(resource);
-
-    ResourceInfo resources = {
-        {"0", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"1", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"2", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"3", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"4", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"5", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"6", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"7", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"8", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"9", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"10", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"11", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"12", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"13", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"14", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"15", gfx::DESCRIPTOR_TEXTURE_TYPE},
+#define TEST_CASE_4                                            \
+    TEST_CASE_DEFINE                                           \
+                                                               \
+    ViewInfo rasterData = {                                    \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{}, {"0"}},                                   \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"0"}, {"1"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"1"}, {"2"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"0"}, {"3"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"3"}, {"19"}},                               \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"3"}, {"5"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"5"}, {"6"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"2"}, {"7"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::RASTER,                                  \
+            {                                                  \
+                {{"7"}, {"8"}},                                \
+            },                                                 \
+        },                                                     \
+        {                                                      \
+            PassType::PRESENT,                                 \
+            {                                                  \
+                {{"7"}, {}},                                   \
+            },                                                 \
+        },                                                     \
+    };                                                         \
+                                                               \
+    LayoutInfo layoutInfo = {                                  \
+        {                                                      \
+            {"0", 0, cc::gfx::ShaderStageFlagBit::VERTEX},     \
+        },                                                     \
+        {                                                      \
+            {"0", 0, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"1", 1, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"1", 1, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"2", 2, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"0", 0, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"3", 3, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"3", 3, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"19", 19, cc::gfx::ShaderStageFlagBit::FRAGMENT}, \
+        },                                                     \
+        {                                                      \
+            {"3", 3, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"5", 5, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"5", 5, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"6", 6, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"2", 2, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+            {"8", 8, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
+        {                                                      \
+            {"7", 7, cc::gfx::ShaderStageFlagBit::FRAGMENT},   \
+        },                                                     \
     };
-
-    ViewInfo data = {
-        {
-            PassType::RASTER,
-            {
-                {{}, {"0", "1", "2"}},
-                {{"0", "1", "2", "4"}, {"3"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"3"}, {"5"}},
-            },
-        },
-        {
-            PassType::PRESENT,
-            {
-                {{"5"}, {}},
-            },
-        },
-    };
-
-    using ShaderStageMap = map<string, gfx::ShaderStageFlagBit>;
-
-    LayoutInfo layoutInfo = {
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::VERTEX},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"2", 2, gfx::ShaderStageFlagBit::VERTEX},
-        },
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::VERTEX},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"2", 2, gfx::ShaderStageFlagBit::VERTEX},
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"4", 4, gfx::ShaderStageFlagBit::VERTEX},
-        },
-        {
-            {"3", 3, gfx::ShaderStageFlagBit::VERTEX},
-            {"5", 5, gfx::ShaderStageFlagBit::VERTEX},
-        },
-        {
-            {"5", 5, gfx::ShaderStageFlagBit::COMPUTE},
-        }};
-
-    testData(data, resources, layoutInfo, renderGraph, rescGraph, layoutGraph);
-    // for(const auto* camera : cameras) {}
-}
-
-void testCase2() {
-    boost::container::pmr::memory_resource *resource = boost::container::pmr::get_default_resource();
-    RenderGraph renderGraph(resource);
-    ResourceGraph rescGraph(resource);
-    LayoutGraphData layoutGraph(resource);
-
-    ResourceInfo resources = {
-        {"0", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"1", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"2", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"3", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"4", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"5", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"6", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"7", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"8", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"9", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"10", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"11", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"12", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"13", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"14", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"15", gfx::DESCRIPTOR_TEXTURE_TYPE},
-    };
-
-    ViewInfo data = {
-        {
-            PassType::RASTER,
-            {
-                {{}, {"0", "1"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"0"}, {"2", "3"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"4", "5"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"3", "5"}, {"6"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"2", "4", "6"}, {"7"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{}, {"8"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"0", "8"}, {"9"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"7", "9"}, {"10"}},
-            },
-        },
-        {
-            PassType::PRESENT,
-            {
-                {{"10"}, {}},
-            },
-        },
-    };
-
-    LayoutInfo layoutInfo = {
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::VERTEX},
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"4", 4, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"4", 4, gfx::ShaderStageFlagBit::VERTEX},
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"9", 9, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"9", 9, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"10", 10, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"10", 10, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-    };
-
-    testData(data, resources, layoutInfo, renderGraph, rescGraph, layoutGraph);
-    // for(const auto* camera : cameras) {}
-}
-
-void testCase3() {
-    boost::container::pmr::memory_resource *resource = boost::container::pmr::get_default_resource();
-    RenderGraph renderGraph(resource);
-    ResourceGraph rescGraph(resource);
-    LayoutGraphData layoutGraph(resource);
-
-    ResourceInfo resources = {
-        {"0", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"1", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"2", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"3", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"4", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"5", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"6", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"7", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"8", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"9", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"10", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"11", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"12", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"13", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"14", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"15", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"16", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"17", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"18", gfx::DESCRIPTOR_TEXTURE_TYPE},
-    };
-
-    ViewInfo data = {
-        {
-            PassType::RASTER,
-            {
-                {{}, {"0"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"0"}, {"1"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"2"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"2"}, {"3"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"3"}, {"4"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"4"}, {"5"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"5"}, {"6"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"3"}, {"7"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"7"}, {"8"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"9"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"14"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"14"}, {"15"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"15", "9"}, {"10"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"16"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"16"}, {"17"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"8", "10", "17"}, {"11"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"11", "6"}, {"12"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"12"}, {"13"}},
-            },
-        },
-        {
-            PassType::PRESENT,
-            {
-                {{"13"}, {}},
-            },
-        },
-    };
-
-    using ShaderStageMap = map<string, gfx::ShaderStageFlagBit>;
-
-    LayoutInfo layoutInfo = {
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"4", 4, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"4", 4, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"9", 9, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"14", 14, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"14", 14, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"15", 15, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"15", 15, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"9", 9, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"10", 10, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"16", 16, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"16", 16, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"17", 17, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"10", 10, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"17", 17, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"11", 11, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"11", 11, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"12", 12, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"12", 12, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"13", 13, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"13", 13, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-    };
-
-    testData(data, resources, layoutInfo, renderGraph, rescGraph, layoutGraph);
-    // for(const auto* camera : cameras) {}
-}
-
-void testCase4() {
-    boost::container::pmr::memory_resource *resource = boost::container::pmr::get_default_resource();
-    RenderGraph renderGraph(resource);
-    ResourceGraph rescGraph(resource);
-    LayoutGraphData layoutGraph(resource);
-
-    ResourceInfo resources = {
-        {"0", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"1", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"2", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"3", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"4", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"5", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"6", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"7", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"8", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"9", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"10", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"11", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"12", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"13", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"14", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"15", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"16", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"17", gfx::DESCRIPTOR_TEXTURE_TYPE},
-        {"18", gfx::DESCRIPTOR_TEXTURE_TYPE},
-    };
-
-    ViewInfo data = {
-        {
-            PassType::RASTER,
-            {
-                {{}, {"0"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"0"}, {"1"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"2"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"2"}, {"3"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"4"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"4"}, {"5"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"1"}, {"6"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"6"}, {"7"}},
-            },
-        },
-        {
-            PassType::RASTER,
-            {
-                {{"7", "5", "3"}, {"8"}},
-            },
-        },
-        {
-            PassType::PRESENT,
-            {
-                {{"8"}, {}},
-            },
-        }};
-
-    using ShaderStageMap = map<string, gfx::ShaderStageFlagBit>;
-
-    LayoutInfo layoutInfo = {
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"0", 0, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"2", 2, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"4", 4, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"4", 4, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"1", 1, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"6", 6, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"3", 3, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"5", 5, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"7", 7, gfx::ShaderStageFlagBit::FRAGMENT},
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-        {
-            {"8", 8, gfx::ShaderStageFlagBit::FRAGMENT},
-        },
-    };
-
-    testData(data, resources, layoutInfo, renderGraph, rescGraph, layoutGraph);
-    // for(const auto* camera : cameras) {}
-}
-*/
 } // namespace render
 } // namespace cc

--- a/native/tests/unit-test/src/framegraph_dispatcher_pass_culling_test.cpp
+++ b/native/tests/unit-test/src/framegraph_dispatcher_pass_culling_test.cpp
@@ -43,7 +43,7 @@ TEST(fgDispatherCulling, test13) {
 
     const auto& barrierMap = fgDispatcher.getBarriers();
     const auto& rag = fgDispatcher.resourceAccessGraph;
-    ExpectEq(rag.vertices.size() == 12, true);
+    ExpectEq(rag.access.size() == 12, true);
 
     ExpectEq(rag.leafPasses.size() == 5, true);
 
@@ -79,6 +79,15 @@ TEST(fgDispatherCulling, test13) {
                  in_degree(9, rag) == 0 && out_degree(9, rag) == 0 &&
                  in_degree(11, rag) != 0 && out_degree(11, rag) == 0,
              true);
+
+    // 6, 7, 9 were culled.
+    // 6 was culled because after leaf 7 was culled, 6 itself becomes a non-writing-externalRes leaf.
+    ExpectEq(rag.culledPasses.size() == 3, true);
+    ExpectEq(rag.culledPasses.find(6) != rag.culledPasses.end() &&
+                 rag.culledPasses.find(7) != rag.culledPasses.end() &&
+                 rag.culledPasses.find(9) != rag.culledPasses.end(),
+             true);
+
 
     // runTestGraph(renderGraph, rescGraph, layoutGraphData, fgDispatcher);
 }

--- a/native/tests/unit-test/src/framegraph_dispatcher_pass_culling_test.cpp
+++ b/native/tests/unit-test/src/framegraph_dispatcher_pass_culling_test.cpp
@@ -1,0 +1,81 @@
+/****************************************************************************
+Copyright (c) 2022 Xiamen Yaji Software Co., Ltd.
+
+http://www.cocos2d-x.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+****************************************************************************/
+#include "cocos/renderer/pipeline/custom/test/test.h"
+#include "gfx-base/GFXDef-common.h"
+#include "gtest/gtest.h"
+#include "utils.h"
+
+TEST(fgDispatherCulling, test13) {
+    // simple graph
+    TEST_CASE_4;
+
+    boost::container::pmr::memory_resource* resource = boost::container::pmr::get_default_resource();
+    RenderGraph renderGraph(resource);
+    ResourceGraph rescGraph(resource);
+    LayoutGraphData layoutGraphData(resource);
+
+    fillTestGraph(rasterData, resources, layoutInfo, renderGraph, rescGraph, layoutGraphData);
+
+    FrameGraphDispatcher fgDispatcher(rescGraph, renderGraph, layoutGraphData, resource, resource);
+    fgDispatcher.run();
+
+    const auto& barrierMap = fgDispatcher.getBarriers();
+    const auto& rag = fgDispatcher.resourceAccessGraph;
+    // ExpectEq(rag.vertices.size() == 4, true);
+
+    // // head
+    // const auto& head = barrierMap.at(0);
+    // ExpectEq(head.blockBarrier.frontBarriers.empty(), true);
+    // ExpectEq(head.blockBarrier.rearBarriers.empty(), true);
+
+    // // 1st node
+    // const auto& node1 = barrierMap.at(1);
+    // ExpectEq(node1.blockBarrier.frontBarriers.empty(), true);
+    // ExpectEq(node1.blockBarrier.rearBarriers.size() == 1, true);
+
+    // ExpectEq(node1.subpassBarriers[0].frontBarriers.empty(), true);
+    // ExpectEq(node1.subpassBarriers[0].rearBarriers.size() == 3, true);
+
+    // ExpectEq(node1.subpassBarriers[1].frontBarriers.empty(), true);
+    // ExpectEq(node1.subpassBarriers[1].rearBarriers.size() == 1, true);
+
+    // const auto& barrier = node1.blockBarrier.rearBarriers[0];
+    // ExpectEq(barrier.type == BarrierType::FULL, true);
+    // ExpectEq(barrier.beginStatus.access == MemoryAccessBit::WRITE_ONLY, true);
+    // // resID 3
+    // ExpectEq(barrier.beginStatus.visibility == std::get<2>(layoutInfo[0][3]), true);
+
+    // //// 2nd node
+    // const auto& node2 = barrierMap.at(2);
+    // ExpectEq(node2.blockBarrier.frontBarriers.empty(), true);
+    // ExpectEq(node2.blockBarrier.rearBarriers.size() == 1, true);
+
+    // const auto& node2RearBarrier0 = node2.blockBarrier.rearBarriers.back();
+    // ExpectEq(node2RearBarrier0.beginStatus.access == MemoryAccessBit::WRITE_ONLY, true);
+    // ExpectEq(node2RearBarrier0.beginStatus.visibility == ShaderStageFlagBit::VERTEX, true);
+    // ExpectEq(node2RearBarrier0.endStatus.access == MemoryAccessBit::READ_ONLY, true);
+    // endstatus: whatever it was, it's COLOR_ATTACHMENT_OPTIMAL
+
+    // runTestGraph(renderGraph, rescGraph, layoutGraphData, fgDispatcher);
+}


### PR DESCRIPTION
Re: #https://github.com/star-e/generator/pull/7

### Changelog
添加了fgdispacther pass culling 及其测例 framegraph_dispatcher_pass_culling_test.cpp:
* 从叶子节点往前找，全是写transient resource的分支会被剪掉；
* 剪掉的行为是从resourceAccessGraph中移出节点及其入边，attachemntStatus信息会被清空；
* 包含supass以整个大pass为单位做culling。

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
