### PR TITLE
fix framegraph dispatcher running case

### DIFF
--- a/native/cocos/renderer/pipeline/custom/test/test.h
+++ b/native/cocos/renderer/pipeline/custom/test/test.h
@@ -172,13 +172,14 @@ static void fillTestGraph(const ViewInfo &rasterData, const ResourceInfo &rescIn
                 dst.name = outputs.front();
                 dst.accessType = AccessType::WRITE;
 
-                computePass.computeViews.emplace(name, ccstd::pmr::vector<ComputeView>{});
-                computePass.computeViews.at(name.c_str()).emplace_back();
-                computePass.computeViews.at(name.c_str()).emplace_back();
-                computePass.computeViews.at(name.c_str()).front().name = inputs.front();
-                computePass.computeViews.at(name.c_str()).front().accessType = AccessType::READ;
-                computePass.computeViews.at(name.c_str()).back().name = outputs.front();
-                computePass.computeViews.at(name.c_str()).back().accessType = AccessType::WRITE;
+                computePass.computeViews.emplace(src.name, ccstd::pmr::vector<ComputeView>{});
+                computePass.computeViews.emplace(dst.name, ccstd::pmr::vector<ComputeView>{});
+                computePass.computeViews.at(src.name.c_str()).emplace_back();
+                computePass.computeViews.at(dst.name.c_str()).emplace_back();
+                computePass.computeViews.at(src.name.c_str()).front().name = inputs.front();
+                computePass.computeViews.at(src.name.c_str()).front().accessType = AccessType::READ;
+                computePass.computeViews.at(dst.name.c_str()).back().name = outputs.front();
+                computePass.computeViews.at(dst.name.c_str()).back().accessType = AccessType::WRITE;
 
                 break;
             }


### PR DESCRIPTION
Re: #

### Changelog
- add fake present pass if there isn't one;
- fix misunderstanding of resource name;
- update test case.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
