### PR TITLE
fix same key of passid

### DIFF
--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -184,7 +184,8 @@ bool tryAddEdge(uint32_t srcVertex, uint32_t dstVertex, Graph &graph);
 
 // for transive_closure.hpp line 231
 inline RelationGraph::vertex_descriptor add_vertex(RelationGraph &g) { // NOLINT
-    return add_vertex(g, INVALID_ID);
+    thread_local uint32_t count = 0; // unused
+    return add_vertex(g, count++);
 }
 
 // status of resource access
@@ -227,7 +228,7 @@ void buildAccessGraph(const RenderGraph &renderGraph, const Graphs &graphs) {
         resourceAccessGraph.leafPasses.emplace(i, LeafStatus{false, false});
     }
 
-    auto startID = add_vertex(resourceAccessGraph, INVALID_ID);
+    auto startID = add_vertex(resourceAccessGraph, INVALID_ID - 1);
     CC_EXPECTS(startID == EXPECT_START_ID);
 
     add_vertex(relationGraph, startID);


### PR DESCRIPTION
Re: #

### Changelog

* INVALID_ID has been used by startID, same for the `add_vertex`

-------

### Continuous Integration

This pull request:

* [x] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
