### PR TITLE
fixed: native custom pipeline graphics pipeline state leak.

### DIFF
--- a/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
@@ -226,11 +226,6 @@ void NativePipeline::updateRenderWindow(const ccstd::string &name, scene::Render
 void NativePipeline::updateRenderTarget(
     const ccstd::string &name,
     uint32_t width, uint32_t height, gfx::Format format) { // NOLINT(bugprone-easily-swappable-parameters)
-}
-
-void NativePipeline::updateDepthStencil(
-    const ccstd::string &name,
-    uint32_t width, uint32_t height, gfx::Format format) { // NOLINT(bugprone-easily-swappable-parameters)
     auto resID = findVertex(ccstd::pmr::string(name, get_allocator()), resourceGraph);
     if (resID == ResourceGraph::null_vertex()) {
         return;
@@ -239,11 +234,20 @@ void NativePipeline::updateDepthStencil(
     visitObject(
         resID, resourceGraph,
         [&](ManagedTexture &tex) {
+            std::ignore = tex;
             desc.width = width;
             desc.height = height;
+            if (format != gfx::Format::UNKNOWN) {
+                desc.format = format;
+            }
         },
         [](const auto & /*res*/) {});
+}
 
+void NativePipeline::updateDepthStencil(
+    const ccstd::string &name,
+    uint32_t width, uint32_t height, gfx::Format format) { // NOLINT(bugprone-easily-swappable-parameters)
+    updateRenderTarget(name, width, height, format);
 }
 
 void NativePipeline::beginFrame() {

--- a/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativePipeline.cpp
@@ -63,6 +63,7 @@
 #include "details/DebugUtils.h"
 #include "details/GslUtils.h"
 #include "pipeline/custom/LayoutGraphUtils.h"
+#include "pipeline/PipelineStateManager.h"
 
 #if CC_USE_DEBUG_RENDERER
     #include "profiler/DebugRenderer.h"
@@ -546,7 +547,7 @@ bool NativePipeline::destroy() noexcept {
         pipelineSceneData->destroy();
         pipelineSceneData = {};
     }
-
+    pipeline::PipelineStateManager::destroyAll();
     return true;
 }
 

--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -162,7 +162,7 @@ void ResourceGraph::mount(gfx::Device* device, vertex_descriptor vertID) {
             buffer.fenceValue = nextFenceValue;
         },
         [&](ManagedTexture& texture) {
-            if (!texture.texture || texture.texture->getWidth() != desc.width || texture.texture->getHeight() != desc.height) {
+            if (!texture.checkResource(desc)) {
                 auto info = getTextureInfo(desc);
                 texture.texture = device->createTexture(info);
             }

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
@@ -380,6 +380,16 @@ RenderGraph::Vertex::Vertex(Vertex const& rhs, const allocator_type& alloc)
   inEdges(rhs.inEdges, alloc),
   handle(rhs.handle) {}
 
+bool ManagedBuffer::checkResource(const ResourceDesc &desc) const {
+    return true;
+}
+
+bool ManagedTexture::checkResource(const ResourceDesc &desc) const {
+    if (!texture) return false;
+    auto &info = texture->getInfo();
+    return desc.width == info.width && desc.height == info.height && desc.format == info.format;
+}
+
 } // namespace render
 
 } // namespace cc

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.cpp
@@ -380,13 +380,9 @@ RenderGraph::Vertex::Vertex(Vertex const& rhs, const allocator_type& alloc)
   inEdges(rhs.inEdges, alloc),
   handle(rhs.handle) {}
 
-bool ManagedBuffer::checkResource(const ResourceDesc &desc) const {
-    return true;
-}
-
 bool ManagedTexture::checkResource(const ResourceDesc &desc) const {
     if (!texture) return false;
-    auto &info = texture->getInfo();
+    const auto &info = texture->getInfo();
     return desc.width == info.width && desc.height == info.height && desc.format == info.format;
 }
 

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -100,8 +100,6 @@ struct ManagedBuffer {
     ManagedBuffer(IntrusivePtr<gfx::Buffer> bufferIn) noexcept // NOLINT
     : buffer(std::move(bufferIn)) {}
 
-    bool checkResource(const ResourceDesc &desc) const;
-
     IntrusivePtr<gfx::Buffer> buffer;
     uint64_t fenceValue{0};
 };

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -100,6 +100,8 @@ struct ManagedBuffer {
     ManagedBuffer(IntrusivePtr<gfx::Buffer> bufferIn) noexcept // NOLINT
     : buffer(std::move(bufferIn)) {}
 
+    bool checkResource(const ResourceDesc &desc) const;
+
     IntrusivePtr<gfx::Buffer> buffer;
     uint64_t fenceValue{0};
 };
@@ -108,6 +110,8 @@ struct ManagedTexture {
     ManagedTexture() = default;
     ManagedTexture(IntrusivePtr<gfx::Texture> textureIn) noexcept // NOLINT
     : texture(std::move(textureIn)) {}
+
+    bool checkResource(const ResourceDesc &desc) const;
 
     IntrusivePtr<gfx::Texture> texture;
     uint64_t fenceValue{0};


### PR DESCRIPTION
Re: #

### Changelog

* fixed: native custom pipeline graphics pipeline state leak.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
