### PR TITLE
fix fg get usage

### DIFF
--- a/native/cocos/renderer/gfx-metal/MTLBuffer.mm
+++ b/native/cocos/renderer/gfx-metal/MTLBuffer.mm
@@ -29,6 +29,7 @@
 #include "MTLBuffer.h"
 #include "MTLCommandBuffer.h"
 #include "MTLDevice.h"
+#include "MTLQueue.h"
 #include "MTLRenderCommandEncoder.h"
 #include "MTLUtils.h"
 #include "MTLGPUObjects.h"
@@ -245,14 +246,26 @@ void CCMTLBuffer::update(const void *buffer, uint32_t size) {
 
 void CCMTLBuffer::updateMTLBuffer(const void *buffer, uint32_t /*offset*/, uint32_t size) {
     if (_gpuBuffer->mtlBuffer) {
-        CommandBuffer *cmdBuffer = CCMTLDevice::getInstance()->getCommandBuffer();
-        cmdBuffer->begin();
-        static_cast<CCMTLCommandBuffer *>(cmdBuffer)->updateBuffer(this, buffer, size);
-#if (CC_PLATFORM == CC_PLATFORM_MACOS)
-        if (_mtlResourceOptions == MTLResourceStorageModeManaged) {
-            [_gpuBuffer->mtlBuffer didModifyRange:NSMakeRange(0, _size)]; // Synchronize the managed buffer.
+        if(_gpuBuffer->mtlBuffer.storageMode == MTLStorageModeShared) {
+            memcpy(_gpuBuffer->mtlBuffer.contents, buffer, size);
+        } else {
+            auto* ccQueue = static_cast<CCMTLQueue*>(CCMTLDevice::getInstance()->getQueue());
+            id<MTLDevice> device = static_cast<id<MTLDevice>>(CCMTLDevice::getInstance()->getMTLDevice());
+            id<MTLCommandQueue> defaultQueue = ccQueue->gpuQueueObj()->mtlCommandQueue;
+            id<MTLCommandBuffer> cmdBuffer = [defaultQueue commandBuffer];
+            id<MTLBlitCommandEncoder> blit = [cmdBuffer blitCommandEncoder];
+            id<MTLBuffer> stagingbuffer = [device newBufferWithBytes:buffer length:size options:MTLStorageModeShared];
+            [blit copyFromBuffer:stagingbuffer sourceOffset:0 toBuffer:_gpuBuffer->mtlBuffer destinationOffset:0 size:size];
+            [blit endEncoding];
+            [stagingbuffer release];
+            [cmdBuffer commit];
+            
+    #if (CC_PLATFORM == CC_PLATFORM_MACOS)
+            if (_mtlResourceOptions == MTLResourceStorageModeManaged) {
+                [_gpuBuffer->mtlBuffer didModifyRange:NSMakeRange(0, _size)]; // Synchronize the managed buffer.
+            }
+    #endif
         }
-#endif
     }
 }
 

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -960,7 +960,7 @@ auto evaluateHeaviness(const RAG &rag, const ResourceGraph &rescGraph, ResourceA
             break;
         }
     }
-    return std::tie(forceAdjacent, score);
+    return std::make_tuple(forceAdjacent, score);
 };
 
 void evaluateAndTryMerge(const RAG &rag, const ResourceGraph &rescGraph, RelationGraph &relationGraph, const RelationGraph &relationGraphTc, const RelationVerts &lhsVerts, const RelationVerts &rhsVerts) {
@@ -1451,7 +1451,7 @@ auto getResourceStatus(PassType passType, const PmrString &name, gfx::MemoryAcce
         accesFlag = gfx::getAccessFlags(texUsage, memAccess, vis);
     }
 
-    return std::tie(vis, usage, accesFlag);
+    return std::make_tuple(vis, usage, accesFlag);
 }
 
 void addCopyAccessStatus(RAG &rag, const ResourceGraph &rg, ResourceAccessNode &node, const ViewStatus &status, const Range &range) {


### PR DESCRIPTION
Re: #

### Changelog

* std::tie forward parameters use Type& as default which cause stack variable reference issue.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
