### PR TITLE
move pass

### DIFF
--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -635,7 +635,9 @@ void cmdFuncCCVKCreateRenderPass(CCVKDevice *device, CCVKGPURenderPass *gpuRende
                 vkDependency.dstAccessMask |= dstAccessMask;
                 dependencyManager.append(vkDependency);
             };
-
+            if (vkDependency.srcStageMask == 0) {
+                vkDependency.srcStageMask = VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT;
+            }
             addStageAccessMask(dependency);
         }
 

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.cpp
@@ -45,7 +45,8 @@ ResourceAccessGraph::ResourceAccessGraph(const allocator_type& alloc) noexcept
   culledPasses(alloc),
   accessRecord(alloc),
   resourceLifeRecord(alloc),
-  topologicalOrder(alloc) {}
+  topologicalOrder(alloc),
+  rpInfos(alloc) {}
 
 // ContinuousContainer
 void ResourceAccessGraph::reserve(vertices_size_type sz) {

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -271,11 +271,10 @@ struct ResourceAccessGraph {
     PmrFlatMap<ccstd::pmr::string, ResourceLifeRecord> resourceLifeRecord;
     std::map<ccstd::pmr::string, ResourceStatus> subResources;
     std::map<ccstd::pmr::string, ccstd::pmr::string> movedPairs;
-    PmrFlatSet<ResourceGraph::vertex_descriptor> writtenResource;
+    PmrFlatSet<ccstd::pmr::string> writtenResource;
     ccstd::pmr::vector<vertex_descriptor> topologicalOrder;
-    PmrFlatMap<vertex_descriptor, FGRenderPassInfo> rpInfos;
-    PmrFlatSet<ccstd::pmr::string> expiredValues;
-    //PmrFlatMap<ResourceGraph::vertex_descriptor, > moveInfo;
+    PmrMap<vertex_descriptor, FGRenderPassInfo> rpInfos;
+    PmrFlatMap<ccstd::pmr::string, ResourceStatus> expiredValues;
 };
 
 struct RelationGraph {

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -258,6 +258,7 @@ struct ResourceAccessGraph {
     PmrFlatMap<ccstd::pmr::string, ResourceLifeRecord> resourceLifeRecord;
     ccstd::pmr::vector<vertex_descriptor> topologicalOrder;
     PmrFlatMap<vertex_descriptor, FGRenderPassInfo> rpInfos;
+    PmrFlatSet<PmrString> expiredValues;
 };
 
 struct RelationGraph {

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -106,9 +106,14 @@ struct ResourceAccessNode {
     struct ResourceAccessNode* nextSubpass{nullptr};
 };
 
+struct LayoutAccess {
+    gfx::AccessFlagBit prevAccess{gfx::AccessFlagBit::NONE};
+    gfx::AccessFlagBit nextAccess{gfx::AccessFlagBit::NONE};
+};
+
 struct FGRenderPassInfo {
-    std::vector<std::pair<gfx::AccessFlags/*prev*/,gfx::AccessFlags/*next*/>> colorAccesses;
-    std::pair<gfx::AccessFlags/*prev*/,gfx::AccessFlags/*next*/> dsAccess;
+    std::vector<LayoutAccess> colorAccesses;
+    LayoutAccess dsAccess;
     gfx::RenderPassInfo rpInfo;
 };
 

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -269,12 +269,11 @@ struct ResourceAccessGraph {
     PmrFlatSet<vertex_descriptor> culledPasses;
     PmrFlatMap<uint32_t, ResourceTransition> accessRecord;
     PmrFlatMap<ccstd::pmr::string, ResourceLifeRecord> resourceLifeRecord;
-    std::map<ccstd::pmr::string, ResourceStatus> subResources;
     std::map<ccstd::pmr::string, ccstd::pmr::string> movedPairs;
     PmrFlatSet<ccstd::pmr::string> writtenResource;
     ccstd::pmr::vector<vertex_descriptor> topologicalOrder;
     PmrMap<vertex_descriptor, FGRenderPassInfo> rpInfos;
-    PmrFlatMap<ccstd::pmr::string, ResourceStatus> expiredValues;
+    PmrFlatMap<ccstd::pmr::string, ResourceStatus> movedResources;
 };
 
 struct RelationGraph {

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -269,7 +269,7 @@ struct ResourceAccessGraph {
     PmrFlatSet<vertex_descriptor> culledPasses;
     PmrFlatMap<uint32_t, ResourceTransition> accessRecord;
     PmrFlatMap<ccstd::pmr::string, ResourceLifeRecord> resourceLifeRecord;
-    std::map<ccstd::pmr::string, ccstd::pmr::string> movedPairs;
+    std::map<ccstd::pmr::string, ccstd::vector<ccstd::pmr::string>> moveTargets;
     PmrFlatSet<ccstd::pmr::string> writtenResource;
     ccstd::pmr::vector<vertex_descriptor> topologicalOrder;
     PmrMap<vertex_descriptor, FGRenderPassInfo> rpInfos;

--- a/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
+++ b/native/cocos/renderer/pipeline/custom/FGDispatcherTypes.h
@@ -436,6 +436,10 @@ struct FrameGraphDispatcher {
 
     void run();
 
+    gfx::Texture* getTexture(const ccstd::pmr::string& name);
+    
+    gfx::Buffer* getBuffer(const ccstd::pmr::string& name);
+
     inline const BarrierMap& getBarriers() const { return barrierMap; }
 
     BarrierMap barrierMap;

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -202,8 +202,8 @@ constexpr uint32_t filledShift(uint8_t pos) {
     return 0xFFFFFFFF >> (32 - pos);
 }
 
-constexpr uint8_t readPos = highestBitPos<static_cast<uint32_t>(gfx::AccessFlagBit::PRESENT)>() - 1;
-constexpr uint32_t READ_ACCESS = filledShift(readPos) | static_cast<uint32_t>(gfx::AccessFlagBit::SHADING_RATE);
+constexpr uint8_t HIGHEST_READ_POS = highestBitPos<static_cast<uint32_t>(gfx::AccessFlagBit::PRESENT)>() - 1;
+constexpr uint32_t READ_ACCESS = filledShift(HIGHEST_READ_POS) | static_cast<uint32_t>(gfx::AccessFlagBit::SHADING_RATE);
 
 inline bool hasReadAccess(gfx::AccessFlagBit flag) {
     return (static_cast<uint32_t>(flag) & READ_ACCESS) != 0;

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -1149,12 +1149,12 @@ void buildBarriers(FrameGraphDispatcher &fgDispatcher) {
             auto &colorAttachments = fgRenderpassInfo.rpInfo.colorAttachments;
             for (uint32_t i = 0; i < colorAttachments.size(); ++i) {
                 const auto &colorAccess = fgRenderpassInfo.colorAccesses[i];
-                colorAttachments[i].barrier = getGeneralBarrier(cc::gfx::Device::getInstance(), colorAccess.first, colorAccess.second);
+                colorAttachments[i].barrier = getGeneralBarrier(cc::gfx::Device::getInstance(), colorAccess.prevAccess, colorAccess.nextAccess);
             }
             auto &dsAttachment = fgRenderpassInfo.rpInfo.depthStencilAttachment;
             if (dsAttachment.format != gfx::Format::UNKNOWN) {
                 const auto &dsAccess = fgRenderpassInfo.dsAccess;
-                dsAttachment.barrier = getGeneralBarrier(cc::gfx::Device::getInstance(), dsAccess.first, dsAccess.second);
+                dsAttachment.barrier = getGeneralBarrier(cc::gfx::Device::getInstance(), dsAccess.prevAccess, dsAccess.nextAccess);
             }
         }
     }
@@ -2112,12 +2112,12 @@ void processRasterPass(const Graphs &graphs, uint32_t passID, const RasterPass &
                         subpassInfo.inputs.emplace_back(index);
                     }
                 }
-                fgRenderpassInfo.colorAccesses[index].first = prevAccess;
-                fgRenderpassInfo.colorAccesses[index].second = nextAccess;
+                fgRenderpassInfo.colorAccesses[index].prevAccess = prevAccess;
+                fgRenderpassInfo.colorAccesses[index].nextAccess = nextAccess;
             } else {
                 subpassInfo.depthStencil = pass.rasterViews.size() - 1;
-                fgRenderpassInfo.dsAccess.first = prevAccess;
-                fgRenderpassInfo.dsAccess.second = nextAccess;
+                fgRenderpassInfo.dsAccess.prevAccess = prevAccess;
+                fgRenderpassInfo.dsAccess.nextAccess = nextAccess;
             }
             fillRenderPassInfo(view, rpInfo, index, viewDesc);
         }
@@ -2219,10 +2219,10 @@ void processRasterSubpass(const Graphs &graphs, uint32_t passID, const RasterSub
                     subpassInfo.inputs.emplace_back(slot);
                 }
             }
-            fgRenderpassInfo.colorAccesses[slot].second = nextAccess;
+            fgRenderpassInfo.colorAccesses[slot].nextAccess = nextAccess;
         } else {
             dsIndex = slotID;
-            fgRenderpassInfo.dsAccess.second = nextAccess;
+            fgRenderpassInfo.dsAccess.nextAccess = nextAccess;
             subpassInfo.depthStencil = rpInfo.colorAttachments.size();
         }
 
@@ -2236,9 +2236,9 @@ void processRasterSubpass(const Graphs &graphs, uint32_t passID, const RasterSub
             auto nextAccess = head->attachmentStatus[slot].accessFlag;
 
             if (view.attachmentType == AttachmentType::DEPTH_STENCIL) {
-                fgRenderpassInfo.dsAccess.first = prevAccess;
+                fgRenderpassInfo.dsAccess.prevAccess = prevAccess;
             } else {
-                fgRenderpassInfo.colorAccesses[slot].first = prevAccess;
+                fgRenderpassInfo.colorAccesses[slot].prevAccess = prevAccess;
             }
             fillRenderPassInfo(view, rpInfo, slot, viewDesc);
         }

--- a/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
+++ b/native/cocos/renderer/pipeline/custom/FrameGraphDispatcher.cpp
@@ -90,6 +90,29 @@ void FrameGraphDispatcher::setParalellWeight(float paralellExecWeight) {
     _paralellExecWeight = clampf(paralellExecWeight, 0.0F, 1.0F);
 }
 
+gfx::Texture* FrameGraphDispatcher::getTexture(const ccstd::pmr::string& name) {
+    auto resID = resourceAccessGraph.resourceIndex.at(name);
+    auto* originTexture = resourceGraph.getTexture(resID);
+    auto iter = resourceAccessGraph.movedResources.find(name);
+    if (iter != resourceAccessGraph.movedResources.end()) {
+        gfx::TextureViewInfo viewInfo;
+        viewInfo.texture = originTexture;
+        viewInfo.type = gfx::TextureType::TEX2D;
+        viewInfo.format = originTexture->getFormat();
+        viewInfo.baseLevel = iter->second.access.range.mipLevel;
+        viewInfo.levelCount = iter->second.access.range.levelCount;
+        viewInfo.baseLayer = iter->second.access.range.firstSlice;
+        viewInfo.layerCount = iter->second.access.range.numSlices;
+        return gfx::Device::getInstance()->createTexture(viewInfo);
+    } else {
+        return originTexture;
+    }
+}
+
+gfx::Buffer *FrameGraphDispatcher::getBuffer(const ccstd::pmr::string &name) {
+    return nullptr;
+}
+
 /////////////////////////////////////////////////////////////////////////////////////INTERNAL⚡IMPLEMENTATION/////////////////////////////////////////////////////////////////////////////////////////////
 
 //---------------------------------------------------------------predefine------------------------------------------------------------------

--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -300,12 +300,16 @@ void ResourceGraph::import(gfx::Texture* texture, vertex_descriptor resID) {
     visitObject(
         resID, *this,
         [&](ManagedTexture& res) {
-            CC_EXPECTS(!res.texture);
-            res.texture = texture;
+            if (!res.texture) {
+                res.texture = texture;
+            }
+            CC_EXPECTS(res.texture);
         },
         [&](IntrusivePtr<gfx::Texture>& tex) {
-            CC_EXPECTS(!tex.get());
-            tex = texture;
+            if (!tex.get()) {
+                tex = texture;
+            }
+            CC_EXPECTS(tex.get());
         },
         [&](auto& rest) {
             CC_EXPECTS(false);

--- a/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
+++ b/native/cocos/renderer/pipeline/custom/NativeResourceGraph.cpp
@@ -296,6 +296,22 @@ gfx::Texture* ResourceGraph::getTexture(vertex_descriptor resID) {
     return texture;
 }
 
+void ResourceGraph::import(gfx::Texture* texture, vertex_descriptor resID) {
+    visitObject(
+        resID, *this,
+        [&](ManagedTexture& res) {
+            CC_EXPECTS(!res.texture);
+            res.texture = texture;
+        },
+        [&](IntrusivePtr<gfx::Texture>& tex) {
+            CC_EXPECTS(!tex.get());
+            tex = texture;
+        },
+        [&](auto& rest) {
+            CC_EXPECTS(false);
+        });
+}
+
 void ResourceGraph::invalidatePersistentRenderPassAndFramebuffer(gfx::Texture* pTexture) {
     if (!pTexture) {
         return;

--- a/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
+++ b/native/cocos/renderer/pipeline/custom/RenderGraphTypes.h
@@ -489,6 +489,7 @@ struct ResourceGraph {
     void unmount(uint64_t completedFenceValue);
     gfx::Texture* getTexture(vertex_descriptor resID);
     gfx::Buffer* getBuffer(vertex_descriptor resID);
+    void import(gfx::Texture* texture, vertex_descriptor v);
     void invalidatePersistentRenderPassAndFramebuffer(gfx::Texture* pTexture);
 
     // ContinuousContainer


### PR DESCRIPTION
Re: #

### Changelog

* test case on the way
* 1. s0 -> s1 -> s2 -> ... -> swapchain : swapchain is the only texture resource been mount.
```
    addOrUpdateRenderTarget("s0", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
    addOrUpdateRenderTarget("s1", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
    addOrUpdateRenderTarget("s2", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
    addOrUpdateRenderTarget("s3", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
    addOrUpdateRenderTarget("s4", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);
    addOrUpdateRenderTarget("s5", gfx.Format.BGRA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);

    addOrUpdateRenderTarget("cube", gfx.Format.RGBA8, width, height, rendering.ResourceResidency.MANAGED, pipeline);

    const clearColor = new gfx.Color(0, 0, 0, 0);

    const pass0 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass0.addRenderTarget('s0', '_', gfx.LoadOp.CLEAR, gfx.StoreOp.STORE, clearColor);
    pass0.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass0.setVec4('solidColor', new Vec4(1.0, 0.0, 0.0, 1.0));
    pass0.setViewport(new gfx.Viewport(0, 0, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s0', 's1', 1, 1, 0, 0, 0));

    const pass1 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass1.addRenderTarget('s1', '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass1.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass1.setVec4('solidColor', new Vec4(0.0, 1.0, 0.0, 1.0));
    pass1.setViewport(new gfx.Viewport(width / 5 * 2, 0, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s1', 's2', 1, 1, 0, 0, 0));

    const pass2 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass2.addRenderTarget('s2', '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass2.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass2.setVec4('solidColor', new Vec4(0.0, 0.0, 1.0, 1.0));
    pass2.setViewport(new gfx.Viewport(width / 5 * 4, 0, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s2', 's3', 1, 1, 0, 0, 0));

    const pass3 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass3.addRenderTarget('s3', '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass3.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass3.setVec4('solidColor', new Vec4(1.0, 0.0, 1.0, 1.0));
    pass3.setViewport(new gfx.Viewport(0, height / 3 * 2, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s3', 's4', 1, 1, 0, 0, 0));

    const pass4 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass4.addRenderTarget('s4', '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass4.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass4.setVec4('solidColor', new Vec4(0.0, 1.0, 1.0, 1.0));
    pass4.setViewport(new gfx.Viewport(width / 5 * 2, height / 3 * 2, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s4', 's5', 1, 1, 0, 0, 0));

    const pass5 = pipeline.addRasterPass(width, height, 'empty-shader');
    pass5.addRenderTarget('s5', '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass5.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addFullscreenQuad(emptyShaderMat, 0);
    pass5.setVec4('solidColor', new Vec4(1.0, 1.0, 0.0, 1.0));
    pass5.setViewport(new gfx.Viewport(width / 5 * 4, height / 3 * 2, width / 5, height / 3));
    pipeline.addMovePass().addPair(new rendering.MovePair('s5', swapchainColor, 1, 1, 0, 0, 0));

    const pass6 = pipeline.addRasterPass(width, height, 'default');
    pass6.addRenderTarget(swapchainColor, '_', gfx.LoadOp.LOAD, gfx.StoreOp.STORE, clearColor);
    pass6.addDepthStencil(swapchainDS, '_', gfx.LoadOp.CLEAR, gfx.StoreOp.STORE, 1.0, gfx.ClearFlagBit.NONE);
    pass6.addQueue(rendering.QueueHint.RENDER_OPAQUE)
        .addSceneOfCamera(camera, new rendering.LightInfo(), rendering.SceneFlags.OPAQUE_OBJECT);
```
![WXWorkCapture_16838798022003](https://github.com/star-e/cocos-engine/assets/18626925/a8d79f0c-956c-4276-8be4-4c99816d8a6c)



-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
