### PR TITLE
update gles3 framebuffer attachent binding && add comment.

### DIFF
--- a/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Commands.cpp
@@ -579,7 +579,7 @@ void cmdFuncGLES2CreateTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture)
     if (gpuTexture->samples > SampleCount::X1) {
         if (device->constantRegistry()->mMSRT != MSRTSupportLevel::NONE &&
             hasFlag(gpuTexture->flags, TextureFlagBit::LAZILY_ALLOCATED)) {
-            gpuTexture->allocateMemory = false;
+            gpuTexture->memoryAllocated = false;
             return;
         }
     }
@@ -801,7 +801,7 @@ void cmdFuncGLES2DestroyTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture
 }
 
 void cmdFuncGLES2ResizeTexture(GLES2Device *device, GLES2GPUTexture *gpuTexture) {
-    if (!gpuTexture->allocateMemory || gpuTexture->glTarget == GL_TEXTURE_EXTERNAL_OES) return;
+    if (!gpuTexture->memoryAllocated || gpuTexture->glTarget == GL_TEXTURE_EXTERNAL_OES) return;
 
     if (gpuTexture->glSamples <= 1) {
         switch (gpuTexture->type) {

--- a/native/cocos/renderer/gfx-gles2/GLES2GPUObjects.h
+++ b/native/cocos/renderer/gfx-gles2/GLES2GPUObjects.h
@@ -121,7 +121,7 @@ struct GLES2GPUTexture {
     SampleCount samples{SampleCount::X1};
     TextureFlags flags{TextureFlagBit::NONE};
     bool isPowerOf2{false};
-    bool allocateMemory{true}; // false if swapchain image or implicit ms render buffer.
+    bool memoryAllocated{true}; // false if swapchain image or implicit ms render buffer.
     GLenum glTarget{0};
     GLenum glInternalFmt{0};
     GLenum glFormat{0};

--- a/native/cocos/renderer/gfx-gles2/GLES2Texture.cpp
+++ b/native/cocos/renderer/gfx-gles2/GLES2Texture.cpp
@@ -59,7 +59,7 @@ void GLES2Texture::doInit(const TextureInfo & /*info*/) {
 
     cmdFuncGLES2CreateTexture(GLES2Device::getInstance(), _gpuTexture);
 
-    if (_gpuTexture->allocateMemory) {
+    if (_gpuTexture->memoryAllocated) {
         GLES2Device::getInstance()->getMemoryStatus().textureSize += _size;
         CC_PROFILE_MEMORY_INC(Texture, _size);
     }
@@ -72,7 +72,7 @@ void GLES2Texture::doInit(const TextureViewInfo &info) {
 void GLES2Texture::doDestroy() {
     if (_gpuTexture) {
         if (!_isTextureView) {
-            if (_gpuTexture->allocateMemory) {
+            if (_gpuTexture->memoryAllocated) {
                 GLES2Device::getInstance()->getMemoryStatus().textureSize -= _size;
                 CC_PROFILE_MEMORY_DEC(Texture, _size);
             }
@@ -85,7 +85,7 @@ void GLES2Texture::doDestroy() {
 }
 
 void GLES2Texture::doResize(uint32_t width, uint32_t height, uint32_t size) {
-    if (_gpuTexture->allocateMemory) {
+    if (_gpuTexture->memoryAllocated) {
         GLES2Device::getInstance()->getMemoryStatus().textureSize -= _size;
         CC_PROFILE_MEMORY_DEC(Texture, _size);
     }
@@ -97,7 +97,7 @@ void GLES2Texture::doResize(uint32_t width, uint32_t height, uint32_t size) {
 
     GLES2Device::getInstance()->framebufferHub()->update(_gpuTexture);
 
-    if (_gpuTexture->allocateMemory) {
+    if (_gpuTexture->memoryAllocated) {
         GLES2Device::getInstance()->getMemoryStatus().textureSize += size;
         CC_PROFILE_MEMORY_INC(Texture, size);
     }
@@ -135,7 +135,7 @@ void GLES2Texture::doInit(const SwapchainTextureInfo & /*info*/) {
     _gpuTexture->samples = _info.samples;
     _gpuTexture->flags = _info.flags;
     _gpuTexture->size = _size;
-    _gpuTexture->allocateMemory = false;
+    _gpuTexture->memoryAllocated = false;
     _gpuTexture->swapchain = static_cast<GLES2Swapchain *>(_swapchain)->gpuSwapchain();
 }
 

--- a/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
@@ -3082,58 +3082,45 @@ void GLES3GPUFramebufferObject::finalize(GLES3GPUStateCache *cache) {
     GL_CHECK(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, handle));
     cache->glDrawFramebuffer = handle;
 
-    ccstd::vector<GLenum> drawBuffers(colors.size(), GL_NONE);
-    for (uint32_t i = 0; i < colors.size(); ++i) {
-        const auto &[view, samples] = colors[i];
-        auto att = static_cast<GLenum>(GL_COLOR_ATTACHMENT0 + i);
-        drawBuffers[i] =att;
-
+    auto bindAttachment = [](GLenum attachment, GLint samples, const GLES3GPUTextureView *view) {
         auto *texture = view->gpuTexture;
         if (samples > 1) {
             CC_ASSERT(view->gpuTexture->glTexture != 0);
             GL_CHECK(glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
-                att,
-                GL_TEXTURE_2D,
-                texture->glTexture,
-                view->baseLevel,
-                static_cast<GLsizei>(samples)));
-            continue;
+                                                          attachment,
+                                                          GL_TEXTURE_2D,
+                                                          texture->glTexture,
+                                                          view->baseLevel,
+                                                          static_cast<GLsizei>(samples)));
+            return;
         }
 
         if (texture->useRenderBuffer) {
+            /*
+             * Renderbuffer is not allocated if using lazily allocated flag.
+             * If the attachment does not meet the implicit MS condition, renderbuffer should be allocated here.
+             */
             if (view->gpuTexture->glRenderbuffer == 0) {
                 GL_CHECK(glGenRenderbuffers(1, &view->gpuTexture->glRenderbuffer));
                 renderBufferStorage(GLES3Device::getInstance(), texture);
             }
-            GL_CHECK(glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, att, texture->glTarget, texture->glRenderbuffer));
+            GL_CHECK(glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, attachment, texture->glTarget, texture->glRenderbuffer));
         } else {
-            GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, att, texture->glTarget, texture->glTexture, view->baseLevel));
+            GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, attachment, texture->glTarget, texture->glTexture, view->baseLevel));
         }
+    };
+
+    ccstd::vector<GLenum> drawBuffers(colors.size(), GL_NONE);
+    for (uint32_t i = 0; i < colors.size(); ++i) {
+        const auto &[view, samples] = colors[i];
+        auto att = static_cast<GLenum>(GL_COLOR_ATTACHMENT0 + i);
+        drawBuffers[i] = att;
+        bindAttachment(att, samples, view);
     }
 
     if (depthStencil.first != nullptr) {
         const auto &[view, samples] = depthStencil;
-
-        auto *texture = view->gpuTexture;
-        if (samples > 1) {
-            CC_ASSERT(view->gpuTexture->glTexture != 0);
-            GL_CHECK(glFramebufferTexture2DMultisampleEXT(GL_FRAMEBUFFER,
-                dsAttachment,
-                GL_TEXTURE_2D,
-                view->gpuTexture->glTexture,
-                view->baseLevel,
-                static_cast<GLsizei>(samples)));
-        } else {
-            if (texture->useRenderBuffer) {
-                if (view->gpuTexture->glRenderbuffer == 0) {
-                    GL_CHECK(glGenRenderbuffers(1, &view->gpuTexture->glRenderbuffer));
-                    renderBufferStorage(GLES3Device::getInstance(), texture);
-                }
-                GL_CHECK(glFramebufferRenderbuffer(GL_DRAW_FRAMEBUFFER, dsAttachment, texture->glTarget, texture->glRenderbuffer));
-            } else {
-                GL_CHECK(glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, dsAttachment, texture->glTarget, texture->glTexture, view->baseLevel));
-            }
-        }
+        bindAttachment(dsAttachment, samples, view);
     }
 
     if (!drawBuffers.empty()) {

--- a/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Commands.cpp
@@ -871,7 +871,7 @@ void cmdFuncGLES3CreateTexture(GLES3Device *device, GLES3GPUTexture *gpuTexture)
         if (gpuTexture->useRenderBuffer &&
             hasFlag(gpuTexture->flags, TextureFlagBit::LAZILY_ALLOCATED)) {
             gpuTexture->glTarget = GL_RENDERBUFFER;
-            gpuTexture->allocateMemory = false;
+            gpuTexture->memoryAllocated = false;
             return;
         }
     }
@@ -925,7 +925,7 @@ void cmdFuncGLES3DestroyTexture(GLES3Device *device, GLES3GPUTexture *gpuTexture
 }
 
 void cmdFuncGLES3ResizeTexture(GLES3Device *device, GLES3GPUTexture *gpuTexture) {
-    if (!gpuTexture->allocateMemory ||
+    if (!gpuTexture->memoryAllocated ||
         hasFlag(gpuTexture->flags, TextureFlagBit::EXTERNAL_OES) ||
         hasFlag(gpuTexture->flags, TextureFlagBit::EXTERNAL_NORMAL)) {
         return;
@@ -2634,7 +2634,7 @@ uint8_t *funcGLES3PixelBufferPick(const uint8_t *buffer, Format format, uint32_t
 }
 
 void cmdFuncGLES3CopyBuffersToTexture(GLES3Device *device, const uint8_t *const *buffers, GLES3GPUTexture *gpuTexture, const BufferTextureCopy *regions, uint32_t count) {
-    if (!gpuTexture->allocateMemory) return;
+    if (!gpuTexture->memoryAllocated) return;
 
     GLuint &glTexture = device->stateCache()->glTextures[device->stateCache()->texUint];
     if (glTexture != gpuTexture->glTexture) {

--- a/native/cocos/renderer/gfx-gles3/GLES3GPUObjects.h
+++ b/native/cocos/renderer/gfx-gles3/GLES3GPUObjects.h
@@ -134,7 +134,7 @@ struct GLES3GPUTexture {
     bool immutable{true};
     bool isPowerOf2{false};
     bool useRenderBuffer{false};
-    bool allocateMemory{true}; // false if swapchain image or implicit ms render buffer.
+    bool memoryAllocated{true}; // false if swapchain image or implicit ms render buffer.
     GLenum glTarget{0};
     GLenum glInternalFmt{0};
     GLenum glFormat{0};

--- a/native/cocos/renderer/gfx-gles3/GLES3Texture.cpp
+++ b/native/cocos/renderer/gfx-gles3/GLES3Texture.cpp
@@ -71,7 +71,7 @@ void GLES3Texture::doInit(const TextureInfo & /*info*/) {
 
     cmdFuncGLES3CreateTexture(GLES3Device::getInstance(), _gpuTexture);
 
-    if (_gpuTexture->allocateMemory) {
+    if (_gpuTexture->memoryAllocated) {
         GLES3Device::getInstance()->getMemoryStatus().textureSize += _size;
         CC_PROFILE_MEMORY_INC(Texture, _size);
     }
@@ -101,7 +101,7 @@ void GLES3Texture::doDestroy() {
     CC_SAFE_DELETE(_gpuTextureView);
     if (_gpuTexture) {
         if (!_isTextureView) {
-            if (_gpuTexture->allocateMemory) {
+            if (_gpuTexture->memoryAllocated) {
                 GLES3Device::getInstance()->getMemoryStatus().textureSize -= _size;
                 CC_PROFILE_MEMORY_DEC(Texture, _size);
             }
@@ -115,7 +115,7 @@ void GLES3Texture::doDestroy() {
 }
 
 void GLES3Texture::doResize(uint32_t width, uint32_t height, uint32_t size) {
-    if (!_isTextureView && _gpuTexture->allocateMemory) {
+    if (!_isTextureView && _gpuTexture->memoryAllocated) {
         GLES3Device::getInstance()->getMemoryStatus().textureSize -= _size;
         CC_PROFILE_MEMORY_DEC(Texture, _size);
     }
@@ -129,7 +129,7 @@ void GLES3Texture::doResize(uint32_t width, uint32_t height, uint32_t size) {
 
     GLES3Device::getInstance()->framebufferHub()->update(_gpuTexture);
 
-    if (!_isTextureView && _gpuTexture->allocateMemory) {
+    if (!_isTextureView && _gpuTexture->memoryAllocated) {
         GLES3Device::getInstance()->getMemoryStatus().textureSize += size;
         CC_PROFILE_MEMORY_INC(Texture, size);
     }
@@ -167,7 +167,7 @@ void GLES3Texture::doInit(const SwapchainTextureInfo & /*info*/) {
     _gpuTexture->glSamples = static_cast<GLint>(_info.samples);
     _gpuTexture->flags = _info.flags;
     _gpuTexture->size = _size;
-    _gpuTexture->allocateMemory = false;
+    _gpuTexture->memoryAllocated = false;
     _gpuTexture->swapchain = static_cast<GLES3Swapchain *>(_swapchain)->gpuSwapchain();
     _gpuTextureView = ccnew GLES3GPUTextureView;
     createTextureView();

--- a/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKCommands.cpp
@@ -158,7 +158,7 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
             VkResult result = vmaCreateImage(device->gpuDevice()->memoryAllocator, &createInfo, &allocInfo,
                                              pVkImage, pVmaAllocation, &res);
             if (!result) {
-                gpuTexture->allocateMemory = false;
+                gpuTexture->memoryAllocated = false;
                 return;
             }
 
@@ -166,7 +166,7 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
             allocInfo.usage = VMA_MEMORY_USAGE_GPU_ONLY;
         }
 
-        gpuTexture->allocateMemory = true;
+        gpuTexture->memoryAllocated = true;
         VK_CHECK(vmaCreateImage(device->gpuDevice()->memoryAllocator, &createInfo, &allocInfo,
                                 pVkImage, pVmaAllocation, &res));
     };
@@ -184,7 +184,7 @@ void cmdFuncCCVKCreateTexture(CCVKDevice *device, CCVKGPUTexture *gpuTexture) {
                 gpuTexture->swapchainVkImages[i] = gpuTexture->swapchain->swapchainImages[i];
             }
         }
-        gpuTexture->allocateMemory = false;
+        gpuTexture->memoryAllocated = false;
     } else if (hasFlag(gpuTexture->flags, TextureFlagBit::EXTERNAL_OES) || hasFlag(gpuTexture->flags, TextureFlagBit::EXTERNAL_NORMAL)) {
         gpuTexture->vkImage = gpuTexture->externalVKImage;
     } else {

--- a/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
+++ b/native/cocos/renderer/gfx-vulkan/VKGPUObjects.h
@@ -159,7 +159,7 @@ struct CCVKGPUTexture : public CCVKGPUDeviceObject {
      * 3. Memory bound manually bound.
      * 4. Sparse Image.
      */
-    bool allocateMemory = true;
+    bool memoryAllocated = true;
 
     VkImage vkImage = VK_NULL_HANDLE;
     VmaAllocation vmaAllocation = VK_NULL_HANDLE;

--- a/native/cocos/renderer/gfx-vulkan/VKTexture.cpp
+++ b/native/cocos/renderer/gfx-vulkan/VKTexture.cpp
@@ -60,7 +60,7 @@ void CCVKTexture::createTexture(uint32_t width, uint32_t height, uint32_t size, 
 
     if (_swapchain != nullptr) {
         _gpuTexture->swapchain = static_cast<CCVKSwapchain *>(_swapchain)->gpuSwapchain();
-        _gpuTexture->allocateMemory = false;
+        _gpuTexture->memoryAllocated = false;
     }
 
     _gpuTexture->type = _info.type;
@@ -121,14 +121,14 @@ void CCVKTexture::doInit(const SwapchainTextureInfo & /*info*/) {
 void CCVKGPUTexture::init() {
     cmdFuncCCVKCreateTexture(CCVKDevice::getInstance(), this);
 
-    if (allocateMemory) {
+    if (memoryAllocated) {
         CCVKDevice::getInstance()->getMemoryStatus().textureSize += size;
         CC_PROFILE_MEMORY_INC(Texture, size);
     }
 }
 
 void CCVKGPUTexture::shutdown() {
-    if (allocateMemory) {
+    if (memoryAllocated) {
         CCVKDevice::getInstance()->getMemoryStatus().textureSize -= size;
         CC_PROFILE_MEMORY_DEC(Texture, size);
     }


### PR DESCRIPTION
Re: #

### Changelog

* update gles3 framebuffer attachent binding && add comment.

-------

### Continuous Integration

This pull request:

* [ ] needs automatic test cases check.
  > Manual trigger with `@cocos-robot run test cases` afterward.
* [ ] does not change any runtime related code or build configuration
  > If any reviewer thinks the CI checks are needed, please uncheck this option, then close and reopen the issue.

-------

### Compatibility Check

This pull request:

* [ ] changes public API, and have ensured backward compatibility with [deprecated features](https://github.com/cocos/cocos-engine/blob/v3.5.0/docs/contribution/deprecated-features.md).
* [ ] affects platform compatibility, e.g. system version, browser version, platform sdk version, platform toolchain, language version, hardware compatibility etc.
* [ ] affects file structure of the build package or build configuration which requires user project upgrade.
* [ ] **introduces breaking changes**, please list all changes, affected features and the scope of violation.

<!-- Note: Makes sure these boxes are checked before submitting your PR - thank you!
- [ ] Your pull request title is using English, it's precise and appropriate.
- [ ] If your pull request has gone "stale", you should **rebase** your work on top of the latest version of the upstream branch.
- [ ] If your commit history is full of small, unimportant commits (such as "fix pep8" or "update tests"), **squash** your commits down to a few, or one, discreet changesets before submitting a pull request.
- [ ] Document new code with comments in source code based on API docs
- [ ] Make sure any runtime log information in `log` , `error` or `new Error('')` has been moved into `EngineErrorMap.md` with an ID, and use `logID(id)` or `new Error(getError(id))` instead.
- To official teams:
  - [ ] Check that your PR is following our [guides](https://github.com/cocos/3d-tasks/blob/master/workflows/readme.md)
-->
